### PR TITLE
Fix for filenames with spaces

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -232,27 +232,27 @@ trap "rm -rf /tmp/vimpager_$$" HUP INT QUIT ILL TRAP KILL BUS TERM
 mkdir /tmp/vimpager_$$
 
 filename=${@:-stdin}
-filename=`echo $filename | tr '/' '_'`
-filename=/tmp/vimpager_${$}/$filename
+filename=`echo "$filename" | tr '/' '_'`
+filename="/tmp/vimpager_${$}/$filename"
 
 case "$@" in
-	*.gz) gunzip -c "$@" | sed -e 's/\[[^m]*m//g' -e 's/.//g' > $filename ;;
-	*.Z) uncompress -c "$@" | sed -e 's/\[[^m]*m//g' -e 's/.//g' > $filename ;;
-	*) sed -e 's/\[[^m]*m//g' -e 's/.//g' "$@" > $filename ;;
+	*.gz) gunzip -c "$@" | sed -e 's/\[[^m]*m//g' -e 's/.//g' > "$filename" ;;
+	*.Z) uncompress -c "$@" | sed -e 's/\[[^m]*m//g' -e 's/.//g' > "$filename" ;;
+	*) sed -e 's/\[[^m]*m//g' -e 's/.//g' "$@" > "$filename" ;;
 esac
 
 # if file is zero length, exit immediately
-if [ ! -s $filename ]; then
+if [ ! -s "$filename" ]; then
 	exit
 fi
 
 # On cygwin it might be the win32 gvim, but windows paths work for cygwin
 # vim just fine as well.
 if [ -n "$cygwin" ]; then
-	filename=`cygpath -w $filename`
+	filename=`cygpath -w "$filename"`
 fi
 
-less_vim -c "${extra_cmd:-echo}" $filename </dev/tty
+less_vim -c "${extra_cmd:-echo}" "$filename" </dev/tty
 
 # terminal vim on OSX can screw up the terminal
 # (but doesn't anymore for some reason...)


### PR DESCRIPTION
`vimpager` would fail when passed a file with spaces in its name:

```
$ touch a\ b
$ ./vimpager a\ b
./vimpager: line 245: [: /tmp/vimpager_89207/a: binary operator expected
2 files to edit
```
