### PR TITLE
Scrolling <Up> and <Down>

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -144,12 +144,16 @@ less_vim() {
 				-u $vimrc \
 				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu' \
 				-c 'nmap <ESC>u :nohlsearch<cr>' \
+				-c 'nmap <Down> 1<C-d>' \
+				-c 'nmap <Up> 1<C-u>' \
 				"${@:--}"
 			else
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
 				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu' \
 				-c 'nmap <ESC>u :nohlsearch<cr>' \
+				-c 'nmap <Down> 1<C-d>' \
+				-c 'nmap <Up> 1<C-u>' \
 				"${@:--}"
 			fi
 			;;


### PR DESCRIPTION
Hi Rafael,

I may be off here, so feel free to chime in. I'm a heavy user of your vimpager and am very happy with it. You may have come across this issue before. Your input is welcome.

Thanks,
Iftekhar.

== Commit Message Below

I usually expect after firing off my pager that pressing down will scroll me
one line down (if possible), and that pressing up will scroll me one line up
(if possible).

With vimpager, I have the trouble that scrolling upwards at the beginning of a
document moves my cursor up, but if I want to move down, I have to invest
keystrokes to move my cursor back to the "scrolloff point" in the document
before any scrolling actually happens.

When quickly viewing man pages or scrolling long git-logs, my fingers will
sometimes move up and down as part of my rhythm, and I've started expecting my
pager to ignore this. Moving up in the beginning of a document or down at the
end of a document has always been meaningless in a read-only paging
environment, so I patched it to behave like that.
