### PR TITLE
Error when using vim versions < 7.3

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -142,13 +142,13 @@ less_vim() {
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
 				-u $vimrc \
-				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | set nornu' \
+				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
 				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				"${@:--}"
 			else
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
-				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | set nornu' \
+				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
 				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				"${@:--}"
 			fi
@@ -215,7 +215,7 @@ less_vim() {
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
 				-u $vimrc \
-				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | if $MYGVIMRC != "" | source $MYGVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | set nornu' \
+				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | if $MYGVIMRC != "" | source $MYGVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
 				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				-c "${colors:-echo}" \
 				-c "${restore:-echo}" \
@@ -224,7 +224,7 @@ less_vim() {
 			else
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
-				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | if $MYGVIMRC != "" | source $MYGVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | set nornu' \
+				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | if $MYGVIMRC != "" | source $MYGVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
 				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				-c "${colors:-echo}" \
 				-c "${restore:-echo}" \


### PR DESCRIPTION
I get an error at opening when using vim < 7.3. This is because it doesn't support vim new feature "relativenumber":

Ignore errors when setting nornu
