### PR TITLE
only source $MYVIMRC/$MYGVIMRC if using non-default rcfiles

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -148,7 +148,7 @@ less_vim() {
 			else
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
-				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
+				-c 'runtime! macros/less.vim | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
 				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				"${@:--}"
 			fi
@@ -224,7 +224,7 @@ less_vim() {
 			else
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
-				-c 'runtime! macros/less.vim | if $MYVIMRC != "" | source $MYVIMRC | endif | if $MYGVIMRC != "" | source $MYGVIMRC | endif | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
+				-c 'runtime! macros/less.vim | set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
 				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				-c "${colors:-echo}" \
 				-c "${restore:-echo}" \


### PR DESCRIPTION
In my `.vimrc` I was hijacking `$MYVIMRC` and sourcing a different
`.vimrc` in a different directory.  This causes `vimpager` to source the
second `.vimrc` file for a second time, which elicited various
complaints from vim about redefined commands and functions.

I know clobbering MYVIMRC is probably questionable, but it doesn't make sense to me that this ever worked correctly if I wasn't clobbering it.  Indeed, some quick testing seems to confirm this is double-sourcing any `.vimrc` if a `$VIMPAGER_RC` (or similar) is not set/found even if `$MYVIMRC` is not clobbered anywhere.
