### PR TITLE
Reorder q -> :q<CR> to fix up/down

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -145,14 +145,14 @@ less_vim() {
 				--cmd 'runtime! macros/less.vim' \
 				-u $vimrc \
 				-c 'set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
-				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u> | noremap q :q<CR>' \
+				-c 'nmap <ESC>u :nohlsearch<cr> | noremap q :q<CR> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				"${@:--}"
 			else
 				$vim_cmd \
 				--cmd 'let vimpager=1' \
 				--cmd 'runtime! macros/less.vim' \
 				-c 'set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
-				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u> | noremap q :q<CR>' \
+				-c 'nmap <ESC>u :nohlsearch<cr> | noremap q :q<CR> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				"${@:--}"
 			fi
 			;;
@@ -220,7 +220,7 @@ less_vim() {
 				--cmd 'runtime! macros/less.vim ' \
 				-u $vimrc \
 				-c 'set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
-				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u> | noremap q :q<CR>' \
+				-c 'nmap <ESC>u :nohlsearch<cr> | noremap q :q<CR> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				-c "${colors:-echo}" \
 				-c "${restore:-echo}" \
 				-c "set lines=$lines | set columns=$cols" \
@@ -230,7 +230,7 @@ less_vim() {
 				--cmd 'let vimpager=1' \
 				--cmd 'runtime! macros/less.vim ' \
 				-c 'set scrolloff='${scrolloff:-5}' | set foldlevel=999 | set nonu | silent! set nornu' \
-				-c 'nmap <ESC>u :nohlsearch<cr> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u> | noremap q :q<CR>' \
+				-c 'nmap <ESC>u :nohlsearch<cr> | noremap q :q<CR> | nnoremap <Down> 1<C-d> | nnoremap <Up> 1<C-u>' \
 				-c "${colors:-echo}" \
 				-c "${restore:-echo}" \
 				-c "set lines=$lines | set columns=$cols" \


### PR DESCRIPTION
With the update from 1.6.8 to v1.7 scrolling up broke for me.

This only occurs when I'm scrolling upwards and encounter a line without any text.
When I attempt to scroll the cursor up, it refuses to move onto (or past) this line.
If I hit page-up, it will get past this barrier (until another such line is encountered).

I narrowed it down to 67da23e59d and when I re-ordered the statements this fixed it.
That being said, I'm not sure _why_ that fixed it...
