### PR TITLE
Reset bg color in vimcat

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -142,6 +142,8 @@ function! s:GroupToAnsi(groupnum)
     let retv .= ";4" . bg
   elseif exists('bg')
     let retv .= ";48;5;" . bg
+  else
+    let retv .= ";49"
   endif
 
   let retv .= "m"


### PR DESCRIPTION
Currently if you use a bg color highlighting it gets set in the ansi escapes but never gets unset, so the rest of your file has that bg color.

This commit adds the ;49 escape so that the bg is reset every time if the bg color is either not set or is the default
