### PR TITLE
Fix vimcat with multiple arguments on the command line

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -134,7 +134,7 @@ function! s:GroupToAnsi(groupnum)
     unlet bg
   endif
 
-  if !exists('bg') && !groupnum == hlID('Normal')
+  if !exists('bg')
     let bg = synIDattr(hlID('Normal'), 'bg', s:type)
     if bg == "" || bg == -1
       unlet bg


### PR DESCRIPTION
Currently each time we call "writefile()" in the vim we overwrite the entire file so you only end up with one file you passed on the output  - this starts vim each tiem to do it per file

This allows "vimcat *" to work. It also adds a header ==>file<== when
there are multiple files (à la 'head'). Although this is significantly
different from 'cat' it seems good as we can't pipe the output of vimcat
to anything else anyway, so the extra adorment seems nice
