### PR TITLE
Reset ANSI foreground colour & omit unnecessary ANSI escape sequences in syntax highlighting

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -154,6 +154,7 @@ function! s:GroupToAnsi(groupnum)
   endif
 
   let retv = "\<Esc>[22;24;25;27;28"
+  let retv = "\<Esc>[39"
 
   if bd
     let retv .= ";1"


### PR DESCRIPTION
I find that vimpager syntax highlighting is pointless/unusable by default, because it never resets the foreground colour to black, so when syntax highlighting occurs, the entire document is coloured instead of just the matched characters. I’m using Mac OS X. vimpager seems to reset everything _except_ the foreground colour. This one-line patch fixes it for me, although I don’t know if it is the complete/proper solution.
