### PR TITLE
Allow ~/.vim/vimpagerrc as init file

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -111,7 +111,7 @@ if [ -n "${VIMPAGER_RC}" ]; then
 	vimrc="${VIMPAGER_RC}"
 elif [ -f ~/.vimpagerrc ]; then
 	vimrc=~/.vimpagerrc
-else [ -f ~/.vim/vimpagerrc ]; then
+elif [ -f ~/.vim/vimpagerrc ]; then
 	vimrc=~/.vim/vimpagerrc
 elif [ -f ~/_vimpagerrc ]; then
 	vimrc=~/_vimpagerrc


### PR DESCRIPTION
This will check for `~/.vim/vimpagerrc` if `~/.vimpagerrc` does not exist.
Motivated by the prctice in Vim itself (see `:h vimrc`).

Also remove some unnecessary whitespace.
