### PR TITLE
Check for _vimrc file too.

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -110,7 +110,7 @@ find_rc() {
 	_rc_file=$2
 
 	[ -e "${HOME}/.${_rc_file}" ] && _rc="${HOME}/.${_rc_file}"
-	[ -e "${HOME}/_${_rc_file}" ] && _rc="${HOME}/_${_rc_file}"
+	[ -z "${_rc}" ] && [ -e "${HOME}/_${_rc_file}" ] && _rc="${HOME}/_${_rc_file}"
 
 	if [ -n "${msys}" -o -n "${cygwin}" ]; then
 		if command -v ${_cmd} 2>/dev/null | grep_q '^\/(cygdrive\/)?[a-z]\/'; then


### PR DESCRIPTION
Even when I'm running Vim on Linux or OS X, I use _vimrc instead of .vimrc because Vim recognizes that name even when not on Windows and this way, I don't have to rename my vimrc file when I switch to Windows. Unfortunately, vimpager does not detect _vimrc. Hence this one-line addition.
