### PR TITLE
Ignore tput errors

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -78,8 +78,8 @@ main() {
 	# Detect terminal size
 	if command -v tput >/dev/null; then
 	        # this is the only way it works on Cygwin
-		tput cols  > "${tmp}/vimpager_cols_${$}"
-		tput lines > "${tmp}/vimpager_lines_${$}"
+		tput cols  > "${tmp}/vimpager_cols_${$}" 2>/dev/null
+		tput lines > "${tmp}/vimpager_lines_${$}" 2>/dev/null
 	
 		cols=$(cat "${tmp}/vimpager_cols_${$}")
 		lines=$(cat "${tmp}/vimpager_lines_${$}")


### PR DESCRIPTION
For example, tput is complaining that xterm-256color is an unknown terminal in MSYS2 when calling the man utility. However it seems to work correctly despite the error message. While this looks like a problem with MSYS2 rather than vimpager, let's not make output dirty with unnecessary errors.

By applying this patch and installing some implementation for `uudecode` (I'm using UUDeview for now), we can get a clean output for man in MSYS2, that is:

```
$ man bash
$
```

Instead of:

```
$ man bash
c:\msys2\mingw32\bin\tput: unknown terminal "xterm-256color"
c:\msys2\mingw32\bin\tput: unknown terminal "xterm-256color"
$
```
