### PR TITLE
Add support for '\x1b[1;39m' (bold)

### DIFF
--- a/ansiesc/autoload/AnsiEsc.vim
+++ b/ansiesc/autoload/AnsiEsc.vim
@@ -126,6 +126,7 @@ fun! AnsiEsc#AnsiEsc(rebuild)
   syn region ansiWhite		start="\e\[;\=0\{0,2};\=37m" end="\e\["me=e-2 contains=ansiConceal
   " set default ansi to white
   syn region ansiWhite          start="\e\[;\=0\{0,2};\=39m" end="\e\["me=e-2 contains=ansiConceal
+  syn region ansiBold          start="\e\[;\=0\{0,1}1;\=39m" end="\e\["me=e-2 contains=ansiConceal
 
   syn region ansiBold     	start="\e\[;\=0\{0,2};\=1m" end="\e\["me=e-2 contains=ansiConceal
   syn region ansiBoldBlack	start="\e\[;\=0\{0,2};\=\%(1;30\|30;1\)m" end="\e\["me=e-2 contains=ansiConceal


### PR DESCRIPTION
As far as I can tell, '\x1b[1;39m' is an escape sequence for bold.
This PR makes AnsiEsc use it as such.

This patch hasn't been tested in anything else than my own terminal (urxvt)

-- 
guiniol