### PR TITLE
Remove unmatched parenthesis from regex

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -350,7 +350,7 @@ main() {
 	esac
 
 	# check for ANSI codes and strip if not using ansiesc
-	if grep_q '(\[;*\??([0-9]+(;[0-9]+)*)?[A-Za-z]))*' "${filename}"; then
+	if grep_q '(\[;*\??([0-9]+(;[0-9]+)*)?[A-Za-z])*' "${filename}"; then
 		if [ -z "${ansiesc_available}" -o -n "${force_strip_ansi}" ]; then
 			mv -- "${filename}" "${filename}.work"
 			cat -- "${filename}.work" | ansi_filter > "${filename}"


### PR DESCRIPTION
My version of awk (`awk version 20070501` on OS X)  gives this error message:
```
awk: syntax error in regular expression ([;*\??([0-9]+(;[0-9]+)*)?[A-Za-z]))* at *
 source line number 3
 context is
                        $0 ~ >>>  /([;*\??([0-9]+(;[0-9]+)*)?[A-Za-z]))*/ <<<
```
There is an extra `)` on the end of the regex.