### PR TITLE
fix invalid comparison operator in vimcat

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -307,7 +307,7 @@ function! s:GroupToAnsi(groupnum)
     unlet fg
   endif
 
-  if !exists('fg') && !groupnum == hlID('Normal')
+  if !exists('fg') && groupnum != hlID('Normal')
     let fg = synIDattr(hlID('Normal'), 'fg', s:type)
     if fg == "" || fg == -1
       unlet fg


### PR DESCRIPTION
Hi, I noticed that the invalid comparison expression caused highlight groups whose colors are "cleared" not displayed in the color of the `normal` group.