### PR TITLE
Fix problems with whitespace in file names

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -328,7 +328,7 @@ main() {
 	done
 
 	filename=${@:-stdin}
-	filename=$(echo "${filename}" | tr '/' '_')
+	filename=$(echo "${filename}" | tr '/ ' '_')
 	filename="${tmp}/${filename}"
 
 	case $(echo "${@}" | tr 'A-Z' 'a-z') in

--- a/vimpager
+++ b/vimpager
@@ -328,7 +328,7 @@ main() {
 	done
 
 	filename=${@:-stdin}
-	filename=$(echo "${filename}" | tr '/ ' '_')
+	filename=$(echo "${filename}" | tr '/[:space:]' '_')
 	filename="${tmp}/${filename}"
 
 	case $(echo "${@}" | tr 'A-Z' 'a-z') in


### PR DESCRIPTION
Vimpager does not seem to like file names with spaces. This should fix it.