### PR TITLE
properly handle options for enabling ansiesc

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -182,7 +182,7 @@ main() {
 
 		let g:use_ansiesc = 0
 
-		if has("conceal") && ((!exists("g:vimpager.ansiesc") || g:vimpager.ansiesc == 1) || (!exists("g:vimpager_disable_ansiesc") || g:vimpager_disable_ansiesc == 0))
+		if has("conceal") && (!exists("g:vimpager.ansiesc") || g:vimpager.ansiesc == 1) && (!exists("g:vimpager_disable_ansiesc") || g:vimpager_disable_ansiesc == 0)
 			let g:use_ansiesc = 1
 		endif
 


### PR DESCRIPTION
Currently, ansiesc is always enabled when g:vimpager_disable_ansiesc is
not set, independently of the value of g:vimpager.ansiesc.

After this patch, it works as expected, when either the old option
g:vimpager_disable_ansiesc or the new g:vimpager.ansiesc are set, but
not both.