### PR TITLE
[RFC] Simplify the finding of an appropriate shell.

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -8,46 +8,32 @@
 
   PATH="$PATH:/usr/local/bin:/opt/csw/bin:/opt/local/bin:/usr/dt/bin:/usr/xpg4/bin:/usr/bin:/bin"
 
-  _MY_SHELL=/bin/sh
-  export _MY_SHELL
 
   if [ -z "$IN_BASH" ] && command -v bash >/dev/null; then
     IN_BASH=1
     export IN_BASH
-    _MY_SHELL=`command -v bash`
-    export _MY_SHELL
     exec bash "$0" "$@"
   elif [ -z "$IN_BASH" ] && [ -z "$IN_KSH" ]; then
     if command -v dtksh >/dev/null; then
       IN_KSH=1
       export IN_KSH
-      _MY_SHELL=`command -v dtksh`
-      export _MY_SHELL
       exec dtksh "$0" "$@"
     elif [ -x /usr/xpg4/bin/sh ]; then
       IN_KSH=1
       export IN_KSH
-      _MY_SHELL=/usr/xpg4/bin/sh
-      export _MY_SHELL
       exec /usr/xpg4/bin/sh "$0" "$@"
     elif command -v ksh93 >/dev/null; then
       IN_KSH=1
       export IN_KSH
-      _MY_SHELL=`command -v ksh93`
-      export _MY_SHELL
       exec ksh93 "$0" "$@"
     elif command -v ksh >/dev/null; then
       IN_KSH=1
       export IN_KSH
-      _MY_SHELL=`command -v ksh`
-      export _MY_SHELL
       exec ksh "$0" "$@"
-    else
-      _MY_SHELL="${SHELL:-/bin/sh}"
     fi
   fi
 
-  # hopefully we're now POSIX, and shell is saved in ${_MY_SHELL}
+  # hopefully we're now POSIX.
 
 quit() {
   rm -rf "${tmp_dir}"

--- a/vimpager
+++ b/vimpager
@@ -14,39 +14,34 @@ fi
 
 PATH=$PATH:/usr/local/bin:/opt/csw/bin:/opt/local/bin:/usr/dt/bin:/usr/xpg4/bin:/usr/bin:/bin
 
-_MY_SHELL=/bin/sh
+_MY_SHELL="${_MY_SHELL:-/bin/sh}"
 export _MY_SHELL
 
 if [ -z "$IN_BASH" ] && command -v bash >/dev/null; then
 	IN_BASH=1
 	export IN_BASH
 	_MY_SHELL=`command -v bash`
-	export _MY_SHELL
 	exec bash "$0" "$@"
 elif [ -z "$IN_BASH" ] && [ -z "$IN_KSH" ]; then
 	if command -v dtksh >/dev/null; then
 		IN_KSH=1
 		export IN_KSH
 		_MY_SHELL=`command -v dtksh`
-		export _MY_SHELL
 		exec dtksh "$0" "$@"
 	elif [ -x /usr/xpg4/bin/sh ]; then
 		IN_KSH=1
 		export IN_KSH
 		_MY_SHELL=/usr/xpg4/bin/sh
-		export _MY_SHELL
 		exec /usr/xpg4/bin/sh "$0" "$@"
 	elif command -v ksh93 >/dev/null; then
 		IN_KSH=1
 		export IN_KSH
 		_MY_SHELL=`command -v ksh93`
-		export _MY_SHELL
 		exec ksh93 "$0" "$@"
 	elif command -v ksh >/dev/null; then
 		IN_KSH=1
 		export IN_KSH
 		_MY_SHELL=`command -v ksh`
-		export _MY_SHELL
 		exec ksh "$0" "$@"
 	fi
 fi
@@ -805,11 +800,11 @@ page_files() {
 				cat "${cur_file}"
 				_exit_status="${?}"
 			else
-				# vimcat uses the same shell finding mechanism, the vars break it
-				unset _MY_SHELL
-				unset IN_BASH
-				unset IN_KSH
-				"${vimcat}" \
+				# vimcat uses the same shell finding mechanism,
+				# so we use the shell we already found and skip
+				# the search in vimcat with our exported
+				# $IN_BASH or $IN_KSH.
+				"${_MY_SHELL}" "${vimcat}" \
 					-u "${vimrc}" \
 					--cmd "set rtp^=${runtime} | let vimpager={ 'enabled': 1 }" \
 					-c 'silent! source %.vim' \


### PR DESCRIPTION
This is a request for comments!  Do not merge immediately.

The variable `_MY_SHELL` is exported in vimpager and in vimcat but it is never used.  The first commit removes it from vimcat.  The second commit uses it in vimpager in order to execute vimcat and thereby skipping the execution of the same algorithm when vimcat is started from vimpager.

Is this acceptable that vimpager now kind of implements a special variable just to call vimcat more efficiently?  Or is it preferable to let vimcat execute the shell finding algorithm on its own again in order to not create a tight coupling between the code in vimpager and vimcat?  In the latter case I could replace the second commit with another one that just removes the `_MY_SHELL` variable from vimpager as well.

Or is there any special meaning to these variables?  They are never used in the code and are mentioned nowhere in any file in the repository.