### PR TITLE
Fix bug from #156 and include commit from #159

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ standalone/%: ${SRC} inc/*
 	fi; \
 	cp $@ ${@}.work; \
 	nlinit="`echo 'nl=\"'; echo '\"'`"; eval "$$nlinit"; \
-	sed "/^[ 	]*\.[ 	]*.*inc\/prologue.sh[ 	]*"'$$'"/{$${nl}\
+	sed "/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*"'$$'"/{$${nl}\
 		x$${nl}\
 		r inc/prologue.sh$${nl}\
 	}" ${@}.work > $@; \
@@ -148,7 +148,7 @@ install: docs vimpager.configured vimcat.configured
 	@echo configuring $<; \
 	MY_SHELL="`scripts/find_shell`"; \
 	sed  -e '1{ s|.*|#!'"$$MY_SHELL"'|; }' \
-	     -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh[ 	]*$$/d' \
+	     -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
 	     -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$MY_SHELL"')"|' \
 	     -e 's!^	PREFIX=.*!	PREFIX=${PREFIX}!' \
 	     -e 's!^	configured=0!	configured=1!' $< > $@; \

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,10 @@ standalone/%: ${SRC} inc/*
 		done; \
 	fi; \
 	cp $@ ${@}.work; \
-	nlinit="`echo 'nl=\"'; echo '\"'`"; eval "$$nlinit"; \
-	sed "/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*"'$$'"/{$${nl}\
-		x$${nl}\
-		r inc/prologue.sh$${nl}\
-	}" ${@}.work > $@; \
+	sed -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/{' \
+	    -e     'r inc/prologue.sh' \
+	    -e     d \
+	    -e '}' ${@}.work > $@; \
 	rm -f ${@}.work; \
 	if grep '^: if 0$$' ${@} >/dev/null; then \
 		scripts/balance-vimcat $@; \

--- a/vimpager
+++ b/vimpager
@@ -9,7 +9,7 @@ if [ ! -t 1 ]; then
 	exec cat "${@}"
 fi
 
-. "${0%/*}/inc/prologue.sh"
+. "`dirname \"$0\"`/inc/prologue.sh"
 
 version="$(cd "${0%/*}"; git describe) (git)"
 


### PR DESCRIPTION
This should now work with the heirloom shell again. (Please check if possible.)

But I just noticed another error with the heirloom shell: it doesn't support `command -v something`.  We might need to address this later if we really want to support this shell as a bootstraping shell.

references: #156 #159