### PR TITLE
Substitute $MY_SHELL in all places when configuring vimpager.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ install: docs vimpager.configured vimcat.configured
 	@echo configuring $<; \
 	MY_SHELL="`scripts/find_shell`"; \
 	sed  -e '1{ s|.*|#!'"$$MY_SHELL"'|; }' \
+	     -e 's|\$${MY_SHELL}|'"$$MY_SHELL|" \
 	     -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
 	     -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$MY_SHELL"')"|' \
 	     -e 's!^	PREFIX=.*!	PREFIX=${PREFIX}!' \


### PR DESCRIPTION
The main script uses the MY_SHELL variable when calling vimcat.

I was also thinking about a note in the docs:

It is possible to set MY_SHELL to some other path when building vimpager.  The makefile will pick that up and put it in the configured script.  For example `make MY_SHELL=/custom/path/to/bash install`.  Should that be noted in the docs or do you not want the MY_SHELL variable to be mentioned in the docs (so it can never be understood to belong to the public interface of vimpager)?

Additionally this also works with the git and standalone version:
```sh
export MY_SHELL=/custom/path/to/bash
PAGER=$PWD/vimpager
 # or
PAGER=$PWD/standalone/vimpager
```
Same question here?