### PR TITLE
Rework handling of arguments.

### DIFF
--- a/ChangeLog_vimpager.yml
+++ b/ChangeLog_vimpager.yml
@@ -33,7 +33,7 @@
 - use mapleader for `,v` mapping in less.vim, defaults to `,`
 - use vim's value of $MYVIMRC and $VIM for finding vimrc or vimpagerrc gh#141
 - disable viminfo, viminfo handling to be improved in the future gh#141
-- support VIMPAGER_DEBUG env var to not suppress vim startup errors
+- support VIMPAGER_DEBUG env var to not suppress vim startup errors and when switching to the next file
 - set global and buffer-local options mostly correctly when switching between less-mode and non-less-mode buffers
 - strip bundled scripts and install them to PREFIX/share/vimpager
 - increase columns in gvim only for docs

--- a/autoload/vimpager.vim
+++ b/autoload/vimpager.vim
@@ -20,6 +20,10 @@ function! vimpager#Init(opts)
     " any pre-processing necessary is written to .vim files
     autocmd BufReadPost,StdinReadPost * silent! source %.vim
 
+    " hide error messages from invalide modelines
+    autocmd BufWinEnter * if !exists('$VIMPAGER_DEBUG') || !$VIMPAGER_DEBUG
+                \ | silent! redraw! | endif
+
     augroup END
 
     augroup vimpager
@@ -28,9 +32,6 @@ function! vimpager#Init(opts)
     " can't use VimEnter because that fires after first file is read
     autocmd BufReadPre,StdinReadPre * call s:SetOptions()
     autocmd BufReadPre,StdinReadPre * runtime macros/less.vim
-
-    " delete the "[No Name]" buffer since we don't use file args
-    autocmd BufReadPre,StdinReadPre * if bufname(1) ==# '' | bdelete 1 | endif
 
     if has('gui')
         autocmd VimEnter * call s:GUIInit()

--- a/autoload/vimpager.vim
+++ b/autoload/vimpager.vim
@@ -18,7 +18,8 @@ function! vimpager#Init(opts)
     autocmd BufReadPre,StdinReadPre * call s:SetBufType()
 
     " any pre-processing necessary is written to .vim files
-    autocmd BufReadPost,StdinReadPost * silent! source %.vim
+    autocmd BufReadPost,StdinReadPost * silent! execute
+                \ 'source ' $VIMPAGER_TMP . '/' . (argidx() + 1) . '.vim'
 
     " hide error messages from invalide modelines
     autocmd BufWinEnter * if !exists('$VIMPAGER_DEBUG') || !$VIMPAGER_DEBUG

--- a/markdown/vimpager.md
+++ b/markdown/vimpager.md
@@ -427,4 +427,4 @@ your PATH and set the vimpager_use_gvim option as described above.
 You can specify the vimrc to use with the `VIMPAGER_RC` environment variable.
 
 Setting `VIMPAGER_DEBUG` to a non-zero value will disable suppressing vim
-errors on startup.
+errors on startup and when switching to the next file.

--- a/markdown_src/vimpager.md
+++ b/markdown_src/vimpager.md
@@ -400,4 +400,4 @@ your PATH and set the vimpager_use_gvim option as described above.
 You can specify the vimrc to use with the `VIMPAGER_RC` environment variable.
 
 Setting `VIMPAGER_DEBUG` to a non-zero value will disable suppressing vim
-errors on startup.
+errors on startup and when switching to the next file.

--- a/prototypes/seq.sh
+++ b/prototypes/seq.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Solaris and some other systems have no seq command
+if [ -z "${_seq}" ]; then
+	if command -v gseq >/dev/null; then
+		_seq=gseq
+	elif command -v seq >/dev/null; then
+		_seq=seq
+	else
+		# For a fallback implementation of seq in oawk see the file
+		# seq.awk.
+		_seq=seq.awk
+	fi
+fi
+
+command "${_seq}" "$@"

--- a/vimpager
+++ b/vimpager
@@ -368,60 +368,69 @@ main() {
 
 		set_key orig_file_names "${file_idx}" "${filename}"
 
+		# $file still holds the orginal file name.  $filename will be
+		# the encoded version of $file.  $tempfile is the path under
+		# $tmp if the file is to be opend from there instead of the
+		# original location.  If $tempfile is empty the file is to be
+		# opened as $file.
 		filename="$(encode_filename "${filename}")"
-		filename="${tmp}/${filename}"
+		tempfile=
 
 		case "$(echo "${file}" | tr 'A-Z' 'a-z')" in
 			*.gz)
 				filename=${filename%.??}
-				gunzip -c -- "${file}" > "${filename}"
+				tempfile="${tmp}/${filename}"
+				gunzip -c -- "${file}" > "${tempfile}"
+
 				;;
 			*.bz2)
 				filename=${filename%.??2}
-				bunzip2 -c -- "${file}" > "${filename}"
+				tempfile="${tmp}/${filename}"
+				bunzip2 -c -- "${file}" > "${tempfile}"
 				;;
 			*.xz)
 				filename=${filename%.??}
-				xzcat -c -- "${file}" > "${filename}"
+				tempfile="${tmp}/${filename}"
+				xzcat -c -- "${file}" > "${tempfile}"
 				;;
 			*.z)
 				filename=${filename%.?}
-				uncompress -c -- "${file}" > "${filename}"
+				tempfile="${tmp}/${filename}"
+				uncompress -c -- "${file}" > "${tempfile}"
 				;;
 			*)
-				if [ "${file}" != "-" ]; then
-					cp -- "${file}" "${filename}"
-				else
-					cat -- "${file}" > "${filename}"
+				if [ "${file}" = "-" ]; then
+					tempfile="${tmp}/${filename}"
+					cat -- "${file}" > "${tempfile}"
 				fi
 				;;
 		esac
 
 		# check for ANSI codes and strip if not using ansiesc
-		if head_n 100 "${filename}" | grep_q "${ANSI_RE}"; then
+		if head_n 100 "${tempfile:-"${file}"}" | grep_q "${ANSI_RE}"; then
 			if [ -z "${ansiesc_available}" -o -n "${force_strip_ansi}" ]; then
-				mv -- "${filename}" "${filename}.work"
-				cat -- "${filename}.work" | ansi_filter > "${filename}"
-				rm -f -- "${filename}.work"
+				ansi_filter "${tempfile:-"${file}"}" > "${tmp}/${filename}.work"
+				tempfile="${tmp}/${filename}"
+				mv -f -- "${tempfile}.work" "${tempfile}"
 			else
 				use_ansiesc=1
-				echo 'call vimpager_utils#DoAnsiEsc()' >> "${filename}.vim"
-				set_key ansi_files "${file_idx}" "${filename}"
+				echo 'call vimpager_utils#DoAnsiEsc()' >> "${tmp}/${file_idx}.vim"
+				set_key ansi_files "${file_idx}" yes
 			fi
 		fi
 
 		# squeeze blank lines if option was specified, Ubuntu man with /usr/bin/pager does this
 		if [ "${squeeze_blank_lines}" = "1" ]; then
-				mv -- "${filename}" "${filename}.work"
 				sed -e '/^[ 	]*$/{
 					N
 					/^[ 	]*\n[ 	]*$/D
-				}' -- "${filename}.work" > "${filename}"
-				rm -f -- "${filename}.work"
+				}' -- < "${tempfile:-"${file}"}" > "${tmp}/${filename}.work"
+				tempfile="${tmp}/${filename}"
+				mv -f -- "${tempfile}.work" "${tempfile}"
 		fi
 
 		# dumb man detection when the pstree heuristic fails
-		if [ -z "${is_doc}" ] && head_n 12 "${filename}" | grep_q '^NAME$'; then
+		if [ -z "${is_doc}" ] && head_n 12 "${tempfile:-"${file}"}" | grep_q '^NAME$'; then
 			is_man=1
 		fi
 
@@ -429,24 +438,25 @@ main() {
 		# and write out ft command for vim
 		if [ -n "${is_doc}" ]; then
 			mv -- "${filename}" "${filename}.work"
-			ansi_filter "${filename}.work" | overstrike_filter | awk '
+			ansi_filter "${tempfile:-"${file}"}" | overstrike_filter | awk '
 				BEGIN { skipblank=1 }
 				/^[ 	]*$/ { if (!skipblank) print }
 				/[^ 	]/ { skipblank=0; print }
-			' > "${filename}"
-			rm -f -- "${filename}.work"
+			' > "${tmp}/${filename}.work"
+			tempfile="${tmp}/${filename}"
+			mv -f -- "${tempfile}.work" "${tempfile}"
 
 			if [ -n "${is_man}" ]; then
-				echo 'set ft=man' >> "${filename}.vim"
+				echo 'set ft=man' >> "${tmp}/${file_idx}.vim"
 			elif [ -n "${is_perldoc}" ]; then
-				echo 'set ft=perldoc' >> "${filename}.vim"
+				echo 'set ft=perldoc' >> "${tmp}/${file_idx}.vim"
 			fi
 		fi
 
 		# if file is zero length, or one blank line (cygwin), and is only arg, exit
-		if [ \( ! -s "${filename}" \) \
-			-o \( \( "$(cat "${filename}")" = "" \) \
-			-a \( "$(wc -l < "${filename}")" -eq 1 \) \) ]; then
+		if [ \( ! -s "${tempfile:-"${file}"}" \) \
+			-o \( \( "$(cat "${tempfile:-"${file}"}")" = "" \) \
+			-a \( "$(wc -l < "${tempfile:-"${file}"}")" -eq 1 \) \) ]; then
 
 			if [ "${#}" -eq 1 ]; then
 				quit 0
@@ -457,9 +467,10 @@ main() {
 		# vim just fine as well.
 		if [ -n "${cygwin}" ]; then
 			filename=$(cygpath -w "${filename}" | tr '\\' /)
+			tempfile=${tempfile:+"${tmp}/${filename}"}
 		fi
 
-		set_key files "${file_idx}" "${filename}"
+		set_key files "${file_idx}" "${tempfile:-"${file}"}"
 
 		file_idx="$((${file_idx} + 1))"
 	done
@@ -772,6 +783,7 @@ page_files() {
 
 	init_opts="'columns': ${cols}, 'tmp_dir': '${tmp}', 'line_numbers': ${line_numbers:-0}, 'is_doc': ${is_doc:-0}"
 
+	VIMPAGER_TMP="${tmp}" \
 	${vim_cmd} -N -i NONE \
 		-u "${vimrc}" \
 		--cmd "set rtp^=${runtime}" \

--- a/vimpager
+++ b/vimpager
@@ -478,9 +478,10 @@ main() {
 	file_count="${#}"
 
 	set --
-
-	for i in $(seq 1 "${file_count}"); do
+	i=1
+	while [ "${i}" -le "${file_count}" ]; do
 		set -- "${@}" "$(get_key files "${i}")"
+		i=$((${i} + 1))
 	done
 
 	if [ "${no_pass_thru:-0}" -ne 1 ] && fits_on_screen "${@}"; then
@@ -561,42 +562,6 @@ sed() {
 	fi
 
 	command "${_sed}" "$@"
-}
-
-# Solaris and some other systems have no seq command
-seq() {
-	if [ -z "${_seq}" ]; then
-		if command -v gseq >/dev/null; then
-			_seq=gseq
-		elif command -v seq >/dev/null; then
-			_seq=seq
-		else
-			_seq=awk_seq
-		fi
-	fi
-
-	command "${_seq}" "$@"
-}
-
-# Fallback implementation of seq in oawk
-awk_seq() {
-	echo | awk '
-	    {
-		start = arg1
-		stop  = arg2
-		step  = 1
-
-		if (num_args == 3) {
-		    step = arg2
-		    stop = arg3
-		}
-
-		for (i = start; i != stop + step; i += step)
-		    print i
-
-		exit(0)
-	    }
-	' num_args="$#" arg1="$1" arg2="$2" arg3="$3"
 }
 
 # grep -q is often not available

--- a/vimpager
+++ b/vimpager
@@ -461,8 +461,6 @@ main() {
 
 		set_key files "${file_idx}" "${filename}"
 
-		vim_files="${vim_files} $(escape_filename_for_vim "${filename}")"
-
 		file_idx="$((${file_idx} + 1))"
 	done
 
@@ -478,7 +476,7 @@ main() {
 		touch "${tmp}/cat_files"
 	fi
 
-	page_files -c "${extra_c:-echo}" --cmd "${extra_cmd:-echo}"
+	page_files "$@"
 
 	quit "${?}"
 }
@@ -718,11 +716,6 @@ BEGIN {
 '
 }
 
-# Escape chars special to vim in file name.
-escape_filename_for_vim() {
-	echo "${@}" | sed -e 's!\([/#%<>|\\ 	]\)!\\\1!g'
-}
-
 # emulate arrays
 set_key() {
 	eval "${1}_${2}=\"${3}\""
@@ -748,11 +741,11 @@ page_files() {
 	fi
 
 	if [ -f "${tmp}/cat_files" ]; then
-		for i in $(seq 1 ${file_count}); do
-			cur_file="$(get_key files "${i}")"
+		i=1
+		for cur_file in "${@}"; do
 			orig_file="$(get_key orig_file_names "${i}")"
 
-			if [ "${file_count}" -gt 1 ]; then
+			if [ "${#}" -gt 1 ]; then
 				if [ "${i}" -gt 1 ]; then
 					printf '\n'
 				fi
@@ -766,26 +759,25 @@ page_files() {
 				"${POSIX_SHELL}" "${vimcat}" \
 					-u "${vimrc}" \
 					--cmd "set rtp^=${runtime} | let vimpager={ 'enabled': 1 }" \
+					--cmd "${extra_cmd:-echo}" \
 					-c 'silent! source %.vim' \
-					"${@}" "${cur_file}" </dev/tty
+					-c "${extra_c:-echo}"  \
+					"${cur_file}" </dev/tty
 				_exit_status="${?}"
 			fi
+			i="$((${i} + 1))"
 		done
 		return "${_exit_status:-0}"
 	fi
 
 	init_opts="'columns': ${cols}, 'tmp_dir': '${tmp}', 'line_numbers': ${line_numbers:-0}, 'is_doc': ${is_doc:-0}"
 
-	quiet='silent! '
-	if [ -n "${VIMPAGER_DEBUG}" -a "${VIMPAGER_DEBUG}" != 0 ]; then
-		quiet=''
-	fi
-
 	${vim_cmd} -N -i NONE \
 		-u "${vimrc}" \
 		--cmd "set rtp^=${runtime}" \
 		--cmd "call vimpager#Init({ ${init_opts} })" \
-		-c "${quiet}args ${vim_files}" \
+		--cmd "${extra_cmd:-echo}" \
+		-c "${extra_c:-echo}"  \
 		"${@}" </dev/tty
 
 	_vim_exit_status="${?}"


### PR DESCRIPTION
I will add more commits as we discuss this, please do not merge suddenly!

This is the first step in order to make it possible to display files without blindly copying them to `/tmp` (discussed in #58 and #162).  It has the additional advantage that it moves shell code to vimscript (like discussed in #149).

@rkitover: In vimpager we escape special chars in the file names. Is that only for the `-c ':args ...'` in `page_files`? Or to put it differently: Can vimcat handle all these chars? If so we I think we can now (after 027cccf) remove the escaping procedure from the main vimpager script and only do it in `vimpager#Init2()` where we have vim's text processing functions at hand and need not care about the version of awk/sed/whatnot that we have.