### PR TITLE
Simplify internal config of vimpager.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ standalone/%: ${SRC} inc/*
 	if grep '^# INCLUDE BUNDLED SCRIPTS' "$$base" >/dev/null; then \
 		cp $@ ${@}.work; \
 		sed -e 's|^version=.*|version="'"`git describe`"' (standalone, shell=\$$(command -v \$$POSIX_SHELL))"|' \
-		    -e 's/^	stripped=1$$/	stripped=0/' \
+		    -e 's/^	standalone=0$$/	standalone=1/' \
+		    -e 's!^	runtime=.*$$!	runtime="\$$tmp/runtime"!' \
+		    -e 's!^	vimcat=.*$$!	vimcat="\$$runtime/bin/vimcat"!' \
 		    -e '/^# INCLUDE BUNDLED SCRIPTS HERE$$/{ q; }' \
 		    ${@}.work > $@; \
 		cat inc/do_uudecode.sh >> $@; \
@@ -147,8 +149,9 @@ install: docs vimpager.configured vimcat.configured
 	    -e 's|\$$POSIX_SHELL|'"$$POSIX_SHELL|" \
 	    -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
 	    -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$POSIX_SHELL"')"|' \
-	    -e 's!^	PREFIX=.*!	PREFIX=${PREFIX}!' \
-	    -e 's!^	configured=0!	configured=1!' $< > $@
+	    -e 's!^	runtime=.*!	runtime=${PREFIX}/share/vimpager!' \
+	    -e 's!^	vimcat=.*!	vimcat=${PREFIX}/bin/vimcat!' \
+	    $< > $@
 	@chmod +x $@
 
 install-deb:

--- a/Makefile
+++ b/Makefile
@@ -34,40 +34,37 @@ standalone/%: ${SRC} inc/*
 	base="`basename $@`"; \
 	cp "$$base" $@; \
 	if grep '^# INCLUDE BUNDLED SCRIPTS' "$$base" >/dev/null; then \
-		cp $@ ${@}.work; \
 		sed -e 's|^version=.*|version="'"`git describe`"' (standalone, shell=\$$(command -v \$$POSIX_SHELL))"|' \
 		    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
 		    -e 's/^	# EXTRACT BUNDLED SCRIPTS HERE$$/	extract_bundled_scripts/' \
 		    -e 's!^	runtime=.*$$!	runtime="\$$tmp/runtime"!' \
 		    -e 's!^	vimcat=.*$$!	vimcat="\$$runtime/bin/vimcat"!' \
 		    -e '/^# INCLUDE BUNDLED SCRIPTS HERE$$/{ q; }' \
-		    ${@}.work > $@; \
-		cat inc/do_uudecode.sh >> $@; \
-		cat inc/bundled_scripts.sh >> $@; \
-		sed -n '/^# END OF BUNDLED SCRIPTS$$/,$$p' "$$base" >> $@; \
+		    $@ > $@.work; \
+		cat inc/do_uudecode.sh >> $@.work; \
+		cat inc/bundled_scripts.sh >> $@.work; \
+		sed -n '/^# END OF BUNDLED SCRIPTS$$/,$$p' "$$base" >> $@.work; \
 		for src in $$SRC; do \
 		    case "$$src" in \
 			inc/*) \
 				continue; \
 				;; \
 		    esac; \
-		    mv $@ ${@}.work; \
 		    src_escaped=`echo $$src | sed -e 's!/!\\\\/!g'`; \
 		    sed -n '/^begin [0-9]* '"$$src_escaped"'/{ q; }; p' $@.work > $@; \
-		    uuencode "$$src" "$$src" > "$${src}.uu"; \
-		    cat "$${src}.uu" >> $@; \
+		    uuencode "$$src" "$$src" >> $@; \
 		    echo EOF >> $@; \
 		    sed -n '/^# END OF '"$$src_escaped"'/,$$p' $@.work >> $@; \
-		    rm -f ${@}.work "$${src}.uu"; \
+		    rm -f $@.work; \
 		done; \
 	fi
-	@cp $@ ${@}.work
+	@cp $@ $@.work
 	@sed -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/{' \
 	    -e     'r inc/prologue.sh' \
 	    -e     d \
-	    -e '}' ${@}.work > $@
-	@rm -f ${@}.work
-	@if grep '^: if 0$$' ${@} >/dev/null; then \
+	    -e '}' $@.work > $@
+	@rm -f $@.work
+	@if grep '^: if 0$$' $@ >/dev/null; then \
 		chmod +x scripts/balance-shellvim; \
 		scripts/balance-shellvim $@; \
 	fi
@@ -140,7 +137,7 @@ install: docs vimpager.configured vimcat.configured
 	    -e 's|\$$POSIX_SHELL|'"$$POSIX_SHELL|" \
 	    -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
 	    -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$POSIX_SHELL"')"|' \
-		    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
+	    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
 	    -e 's!^	runtime=.*!	runtime=${PREFIX}/share/vimpager!' \
 	    -e 's!^	vimcat=.*!	vimcat=${PREFIX}/bin/vimcat!' \
 	    $< > $@

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ standalone/%: ${SRC} inc/*
 	if grep '^# INCLUDE BUNDLED SCRIPTS' "$$base" >/dev/null; then \
 		cp $@ ${@}.work; \
 		sed -e 's|^version=.*|version="'"`git describe`"' (standalone, shell=\$$(command -v \$$POSIX_SHELL))"|' \
+		    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
 		    -e 's/^	standalone=0$$/	standalone=1/' \
 		    -e 's!^	runtime=.*$$!	runtime="\$$tmp/runtime"!' \
 		    -e 's!^	vimcat=.*$$!	vimcat="\$$runtime/bin/vimcat"!' \
@@ -149,6 +150,7 @@ install: docs vimpager.configured vimcat.configured
 	    -e 's|\$$POSIX_SHELL|'"$$POSIX_SHELL|" \
 	    -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
 	    -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$POSIX_SHELL"')"|' \
+		    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
 	    -e 's!^	runtime=.*!	runtime=${PREFIX}/share/vimpager!' \
 	    -e 's!^	vimcat=.*!	vimcat=${PREFIX}/bin/vimcat!' \
 	    $< > $@

--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,12 @@ install: docs vimpager.configured vimcat.configured
 %.configured: %
 	@echo configuring $<
 	@POSIX_SHELL="`scripts/find_shell`"; \
-	sed  -e '1{ s|.*|#!'"$$POSIX_SHELL"'|; }' \
-	     -e 's|\$$POSIX_SHELL|'"$$POSIX_SHELL|" \
-	     -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
-	     -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$POSIX_SHELL"')"|' \
-	     -e 's!^	PREFIX=.*!	PREFIX=${PREFIX}!' \
-	     -e 's!^	configured=0!	configured=1!' $< > $@
+	sed -e '1{ s|.*|#!'"$$POSIX_SHELL"'|; }' \
+	    -e 's|\$$POSIX_SHELL|'"$$POSIX_SHELL|" \
+	    -e '/^[ 	]*\.[ 	]*.*inc\/prologue.sh.*$$/d' \
+	    -e 's|^version=.*|version="'"`git describe`"' (configured, shell='"$$POSIX_SHELL"')"|' \
+	    -e 's!^	PREFIX=.*!	PREFIX=${PREFIX}!' \
+	    -e 's!^	configured=0!	configured=1!' $< > $@
 	@chmod +x $@
 
 install-deb:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ standalone/%: ${SRC} inc/*
 		cp $@ ${@}.work; \
 		sed -e 's|^version=.*|version="'"`git describe`"' (standalone, shell=\$$(command -v \$$POSIX_SHELL))"|' \
 		    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
-		    -e 's/^	standalone=0$$/	standalone=1/' \
+		    -e 's/^	# EXTRACT BUNDLED SCRIPTS HERE$$/	extract_bundled_scripts/' \
 		    -e 's!^	runtime=.*$$!	runtime="\$$tmp/runtime"!' \
 		    -e 's!^	vimcat=.*$$!	vimcat="\$$runtime/bin/vimcat"!' \
 		    -e '/^# INCLUDE BUNDLED SCRIPTS HERE$$/{ q; }' \

--- a/inc/bundled_scripts.sh
+++ b/inc/bundled_scripts.sh
@@ -1,3 +1,30 @@
+extract_bundled_scripts() {
+	mkdir "$runtime"
+
+	(
+		cd "$runtime"
+
+		mkdir macros autoload plugin syntax bin
+
+		# we extract all files in case the user uses :Page or :Page!
+		autoload_vimpager_vim
+		autoload_vimpager_utils_vim
+		plugin_vimpager_vim
+		less_vim
+
+		perldoc_vim
+
+		ansi_esc_vim
+		ansi_esc_plugin_vim
+		cecutil_plugin_vim
+
+		if [ -n "$cat_files" ]; then
+			vimcat_script
+			chmod +x ./bin/vimcat
+		fi
+	)
+}
+
 less_vim() {
 	(cat <<'EOF') | do_uudecode > macros/less.vim
 begin 644 macros/less.vim

--- a/vimpager
+++ b/vimpager
@@ -119,13 +119,6 @@ main() {
 
 	# determine if this script is stripped/installed or not
 	config
-	if [ "$stripped" -eq 0 ]; then
-		runtime="$tmp/runtime"
-	elif [ "$configured" -eq 0 ]; then
-		runtime="$project_dir"
-	else
-		runtime="$PREFIX/share/vimpager"
-	fi
 
 	# determine location of rc file
 	i=1
@@ -746,17 +739,8 @@ get_key() {
 
 # this actually runs vim or gvim, or vimcat, or just cats the file
 page_files() {
-	if [ "$stripped" -eq 0 ]; then
+	if [ "$standalone" -eq 1 ]; then
 		extract_bundled_scripts
-		vimcat="$runtime/bin/vimcat"
-	else
-		if command -v vimcat > /dev/null; then
-			vimcat="$(command -v vimcat)"
-		elif [ "$configured" -eq 0 ]; then
-			vimcat="$project_dir/vimcat"
-		else
-			vimcat="$PREFIX/bin/vimcat"
-		fi
 	fi
 
 	if [ -n "$cat_files" ]; then
@@ -917,9 +901,9 @@ fits_on_screen() {
 }
 
 config() {
-	stripped=1
-	configured=0
-	PREFIX="$project_dir"
+	standalone=0
+	runtime="$project_dir"
+	vimcat="$project_dir/vimcat"
 }
 
 # INCLUDE BUNDLED SCRIPTS HERE

--- a/vimpager
+++ b/vimpager
@@ -696,33 +696,6 @@ line_n() {
 	head_n "$_line" "$@" | tail_n 1
 }
 
-extract_bundled_scripts() {
-	mkdir "$runtime"
-
-	(
-		cd "$runtime"
-
-		mkdir macros autoload plugin syntax bin
-
-		# we extract all files in case the user uses :Page or :Page!
-		autoload_vimpager_vim
-		autoload_vimpager_utils_vim
-		plugin_vimpager_vim
-		less_vim
-
-		perldoc_vim
-
-		ansi_esc_vim
-		ansi_esc_plugin_vim
-		cecutil_plugin_vim
-
-		if [ -n "$cat_files" ]; then
-			vimcat_script
-			chmod +x ./bin/vimcat
-		fi
-	)
-}
-
 # We are escaping only slashes (because they are special in file paths) and
 # percent (because it is our escape char).  This makes it possible to encode
 # the path to the original file in the basename of the temporary file.
@@ -741,9 +714,7 @@ get_key() {
 
 # this actually runs vim or gvim, or vimcat, or just cats the file
 page_files() {
-	if [ "$standalone" -eq 1 ]; then
-		extract_bundled_scripts
-	fi
+	# EXTRACT BUNDLED SCRIPTS HERE
 
 	if [ -n "$cat_files" ]; then
 		i=1
@@ -903,7 +874,6 @@ fits_on_screen() {
 }
 
 config() {
-	standalone=0
 	runtime="$project_dir"
 	vimcat="$project_dir/vimcat"
 }

--- a/vimpager
+++ b/vimpager
@@ -780,7 +780,7 @@ page_files() {
 					--cmd "set rtp^=$runtime | let vimpager={ 'enabled': 1 }" \
 					--cmd "${extra_cmd:-echo}" \
 					-c 'silent! source '"$tmp/$i"'.vim' \
-					-c "${extra_c:-echo}"  \
+					-c "${extra_c:-echo}" \
 					"$cur_file" </dev/tty
 				_exit_status=$?
 			fi
@@ -797,7 +797,7 @@ page_files() {
 		--cmd "silent! exe 'source ' . fnameescape('$system_vimrc')" \
 		--cmd "${extra_cmd:-echo}" \
 		-u "$vimrc" \
-		-c "${extra_c:-echo}"  \
+		-c "${extra_c:-echo}" \
 		"$@" </dev/tty
 
 	_vim_exit_status=$?

--- a/vimpager
+++ b/vimpager
@@ -9,6 +9,7 @@ if [ ! -t 1 ]; then
 	exec cat "$@"
 fi
 
+# FIND REAL PARENT DIRECTORY
 link="$0"
 
 while true; do
@@ -21,6 +22,7 @@ while true; do
 done
 
 project_dir="`dirname \"$link\"`"
+# END OF FIND REAL PARENT DIRECTORY
 
 . "$project_dir""/inc/prologue.sh"
 


### PR DESCRIPTION
The runtime checks are moved to the makefile as the makefile is already doing very similar replacements.

Also some code that is only needed when running from git is removed.