### PR TITLE
Remove unused functions.

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -636,12 +636,6 @@ else
 	_head=head
 fi
 
-if command -v gtail >/dev/null; then
-	_tail=gtail
-elif [ -x /usr/xpg4/bin/tail ]; then
-	_tail=/usr/xpg4/bin/tail
-fi
-
 if [ "$(echo xx | head -n 1 2>/dev/null)" = "xx" ]; then
 	_head_syntax=new
 else
@@ -667,40 +661,6 @@ head() {
 	else
 		command "$_head" -$_lines "$@"
 	fi
-}
-
-if [ "$(echo xx | tail -n 1 2>/dev/null)" = "xx" ]; then
-	_tail_syntax=new
-else
-	if ! tail -1 -- "$0" > /dev/null 2>&1; then
-		_tail_no_double_dash=1
-	fi
-fi
-
-tail() {
-	_lines=
-	case "$1" in
-		-[0-9]*)
-			_lines="${1#-}"
-			shift
-	esac
-
-	if [ -z "$_lines" ]; then
-		command "$_tail" "$@"
-	elif [ "$_tail_syntax" = "new" ]; then
-		command "$_tail" -n "$_lines" -- "$@"
-	elif [ -z "$_tail_no_double_dash" ]; then
-		command "$_tail" -"$_lines" -- "$@"
-	else
-		command "$_tail" -"$_lines" "$@"
-	fi
-}
-
-line_n() {
-	_line="$1"
-	shift
-
-	head -"$_line" "$@" | tail -1
 }
 
 # We are escaping only slashes (because they are special in file paths) and


### PR DESCRIPTION
`line_n()` was not used since b8e8d984eee2df12d2443cff1df03b37cbff0c9e and it
was the only place where tail was used.

If need be `line_n()` can also be reimplemented without tail with the help of
sed:

```sh
line_n() {
    line=$1
    shift
    sed -n "$line{p;q;}" "$@"
}
```