### PR TITLE
move config vars to the top of the script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,16 @@ RUNTIME=autoload/vimpager.vim autoload/vimpager_utils.vim plugin/vimpager.vim ma
 
 SRC=vimcat ${RUNTIME}
 
+PROGRAMS=vimpager vimcat
+
 all: balance-shellvim-stamp standalone/vimpager standalone/vimcat docs
 
-balance-shellvim-stamp: vimcat
+balance-shellvim-stamp: vimcat Makefile
 	@chmod +x scripts/balance-shellvim
 	@scripts/balance-shellvim
 	@touch balance-shellvim-stamp
 
-standalone/%: ${SRC} inc/*
+standalone/%: ${PROGRAMS} ${SRC} inc/* Makefile
 	@echo building $@
 	@${MKPATH} `dirname $@`
 	@base="`basename $@`"; \
@@ -36,8 +38,8 @@ standalone/%: ${SRC} inc/*
 		cp $@ $@.work; \
 		sed -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
 		    -e 's/^\( *\)# EXTRACT BUNDLED SCRIPTS HERE$$/\1extract_bundled_scripts/' \
-		    -e 's!^\( *\)runtime=.*$$!\1runtime="\$$tmp/runtime"!' \
-		    -e 's!^\( *\)vimcat=.*$$!\1vimcat="\$$runtime/bin/vimcat"!' \
+		    -e 's!^runtime=.*$$!runtime='\''\$$tmp/runtime'\''!' \
+		    -e 's!^vimcat=.*$$!vimcat='\''\$$runtime/bin/vimcat'\''!' \
 		    -e '/^# INCLUDE BUNDLED SCRIPTS HERE$$/{ q; }' \
 		    $@.work > $@; \
 		cat inc/do_uudecode.sh >> $@; \
@@ -55,7 +57,7 @@ standalone/%: ${SRC} inc/*
 	fi
 	@cp $@ $@.work
 	@sed -e 's|^\( *\)version=.*|\1version="'"`git describe`"' (standalone, shell=\$$(command -v \$$POSIX_SHELL))"|' \
-	    -e '/^ *\. .*inc\/prologue.sh.*$$/{' \
+	    -e '/^ *\. .*inc\/prologue.sh"$$/{' \
 	    -e     'r inc/prologue.sh' \
 	    -e     d \
 	    -e '}' $@.work > $@
@@ -131,11 +133,11 @@ install: docs vimpager.configured vimcat.configured
 	@POSIX_SHELL="`scripts/find_shell`"; \
 	sed -e '1{ s|.*|#!'"$$POSIX_SHELL"'|; }' \
 	    -e 's|\$$POSIX_SHELL|'"$$POSIX_SHELL|" \
-	    -e '/^ *\. .*inc\/prologue.sh.*$$/d' \
+	    -e '/^ *\. .*inc\/prologue.sh"$$/d' \
 	    -e 's|^\( *\)version=.*|\1version="'"`git describe`"' (configured, shell='"$$POSIX_SHELL"')"|' \
 	    -e '/^# FIND REAL PARENT DIRECTORY$$/,/^# END OF FIND REAL PARENT DIRECTORY$$/d' \
-	    -e 's!^\( *\)runtime=.*!\1runtime=${PREFIX}/share/vimpager!' \
-	    -e 's!^\( *\)vimcat=.*!\1vimcat=${PREFIX}/bin/vimcat!' \
+	    -e 's!^\( *\)runtime=.*!\1runtime="${PREFIX}/share/vimpager"!' \
+	    -e 's!^\( *\)vimcat=.*!\1vimcat="${PREFIX}/bin/vimcat"!' \
 	    $< > $@
 	@chmod +x $@
 
@@ -160,10 +162,10 @@ install-deb:
 	@apt-get -y autoremove
 	@debian/rules clean
 
-docs: ${GEN_DOCS} docs.tar.gz
+docs: ${GEN_DOCS} docs.tar.gz Makefile
 	@rm -f docs-warn-stamp doctoc-warn-stamp
 
-docs.tar.gz: ${GEN_DOCS} ${DOC_SRC}
+docs.tar.gz: ${GEN_DOCS} ${DOC_SRC} Makefile
 	@rm -f $@
 	@if [ "`ls -1 $? 2>/dev/null | wc -l`" -eq "`echo $? | wc -w`" ]; then \
 		echo tar cf docs.tar $?; \

--- a/vimpager
+++ b/vimpager
@@ -24,14 +24,16 @@ done
 project_dir="`dirname \"$link\"`"
 # END OF FIND REAL PARENT DIRECTORY
 
-. "$project_dir""/inc/prologue.sh"
+. "$project_dir/inc/prologue.sh"
 
 version="$(cd "$project_dir"; git describe) (git)"
+runtime='$project_dir'
+vimcat='$project_dir/vimcat'
 
-case $(uname -s) in
+case "$(uname -s)" in
     Linux) linux=1 ;;
     SunOS) solaris=1 ;;
-        Darwin) osx=1; bsd=1 ;;
+    Darwin) osx=1; bsd=1 ;;
     CYGWIN*) cygwin=1; win32=1 ;;
     MINGW*) msys=1; win32=1 ;;
     MSYS*) msys=1; win32=1 ;;
@@ -120,8 +122,7 @@ main() {
         no_pass_thru=1 # force loading vimpager
     fi
 
-    # determine if this script is stripped/installed or not
-    config
+    expand_config_vars
 
     # determine location of rc file
     i=1
@@ -539,6 +540,11 @@ main() {
     quit $?
 }
 
+expand_config_vars() {
+    eval runtime=\"$runtime\"
+    eval vimcat=\"$vimcat\"
+}
+
 # special handling to rewrite cygwin/msys paths to windows POSIX paths
 if [ -n "$win32" ] && command -v cygpath >/dev/null; then
     _have_cygpath=1
@@ -879,11 +885,6 @@ fits_on_screen() {
         if (!--lines) exit(1)
     }
     ' num_files=$# total_lines=$lines total_cols=$cols file_sep_lines=3 first_file_sep_lines=2 -
-}
-
-config() {
-    runtime="$project_dir"
-    vimcat="$project_dir/vimcat"
 }
 
 # INCLUDE BUNDLED SCRIPTS HERE


### PR DESCRIPTION
@lucc

Move the config vars to the top of the script next to version, run them
through eval after setting tmp (for the standalone version, since the
runtime is a subdir of tmp.)

Also add Makefile as a dependency for a few of the Makefile recipes, so
they rebuild when Makefile is changed.