### PR TITLE
Improve finding of `$vimrc` and option parsing.

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -50,10 +50,16 @@ main() {
         quit 0
     fi
 
-    # check for -h and -v before main option parsing, this is much faster
-    # set xtrace as early as possible, if requested
-    for arg in "$@"; do
-        case "$arg" in
+    # Parse the command line options as early as possible.  These variables might be set because of command line options and are thus initialized.
+    vim_options=
+    vimrc=
+    extra_c=
+    extra_cmd=
+    line_numbers=0
+    # Check for certain parameters to pass on to vim (or conceivably do something else)
+    # Couldn't use getopt or getopts as neither supports options prepended with +
+    while [ $# -gt 0 ] ; do
+        case "$1" in
             '-h'|'--help'|'-help'|'--usage'|'-usage')
                 usage
                 quit 0
@@ -62,11 +68,61 @@ main() {
                 echo "vimpager $version"
                 quit 0
                 ;;
+            '+G'|'+')
+                vim_options="$vim_options +";
+                shift
+                ;;
+            '-N'|'--LINE-NUMBERS')
+                line_numbers=1
+                shift
+                ;;
+            '-c')
+                shift
+                if [ -z "$extra_c" ]; then
+                    extra_c="$1"
+                else
+                    extra_c="$extra_c | $1"
+                fi
+                shift
+                ;;
+            '--cmd')
+                shift
+                if [ -z "$extra_cmd" ]; then
+                    extra_cmd="$1"
+                else
+                    extra_cmd="$extra_cmd | $1"
+                fi
+                shift
+                ;;
+            '-u')
+                shift
+                vimrc="$1"
+                shift
+                ;;
+            '-s') # Ubuntu man passes this option to /usr/bin/pager
+                shift
+                squeeze_blank_lines=1
+                ;;
+            '--')
+                shift
+                break
+                ;;
             '-x')
                 trace=1
+                shift
                 set -x
                 ;;
-        esac
+            -)
+                break
+                ;;
+            -*)
+                echo "$0: bad option '$1', see --help for usage." >&2
+                quit 1
+                ;;
+            *)
+                break
+                ;;
+         esac
     done
 
     mkdir_options="-m 700"
@@ -267,67 +323,7 @@ main() {
         force_strip_ansi=1
     fi
 
-    extra_cmd="let g:vimpager.ptree=[$(echo "$ptree" | awk '{ print "\"" $2 "\"" }' | tr '\n' ',')] | call remove(g:vimpager.ptree, -1) | let g:vimpager_ptree = g:vimpager.ptree"
-
-    # Check for certain parameters to pass on to vim (or conceivably do something else)
-    # Couldn't use getopt or getopts as neither supports options prepended with +
-    while [ $# -gt 0 ] ; do
-        case "$1" in
-            '+G'|'+')
-                vim_cmd="$vim_cmd +";
-                shift
-                ;;
-            '-N'|'--LINE-NUMBERS')
-                line_numbers=1
-                shift
-                ;;
-            '-c')
-                shift
-                if [ -z "$extra_c" ]; then
-                    extra_c="$1"
-                else
-                    extra_c="$extra_c | $1"
-                fi
-                shift
-                ;;
-            '--cmd')
-                shift
-                if [ -z "$extra_cmd" ]; then
-                    extra_cmd="$1"
-                else
-                    extra_cmd="$extra_cmd | $1"
-                fi
-                shift
-                ;;
-            '-u')
-                shift
-                vimrc="$1"
-                shift
-                ;;
-            '-s') # Ubuntu man passes this option to /usr/bin/pager
-                shift
-                squeeze_blank_lines=1
-                ;;
-            '--')
-                shift
-                break
-                ;;
-            '-x')
-                # xtrace should already be set by the first option parsing
-                shift
-                ;;
-            -)
-                break
-                ;;
-            -*)
-                echo "$0: bad option '$1', see --help for usage." >&2
-                quit 1
-                ;;
-            *)
-                break
-                ;;
-         esac
-    done
+    extra_cmd="${extra_cmd:+$extra_cmd | }let g:vimpager.ptree=[$(echo "$ptree" | awk '{ print "\"" $2 "\"" }' | tr '\n' ',')] | call remove(g:vimpager.ptree, -1) | let g:vimpager_ptree = g:vimpager.ptree"
 
     # if no args, assume stdin
     if [ $# -eq 0 ]; then
@@ -769,6 +765,7 @@ page_files() {
     init_opts="'columns': $cols, 'tmp_dir': '$tmp', 'line_numbers': ${line_numbers:-0}, 'is_doc': ${is_doc:-0}, 'runtime': '$runtime'"
 
     $vim_cmd -N -i NONE \
+        $vim_options \
         --cmd "set rtp^=$runtime" \
         --cmd "call vimpager#Init({ $init_opts })" \
         --cmd "silent! exe 'source ' . fnameescape('$system_vimrc')" \

--- a/vimpager
+++ b/vimpager
@@ -60,46 +60,46 @@ main() {
     # Couldn't use getopt or getopts as neither supports options prepended with +
     while [ $# -gt 0 ] ; do
         case "$1" in
-            '-h'|'--help'|'-help'|'--usage'|'-usage')
+            -h|--help|-help|--usage|-usage)
                 usage
                 quit 0
                 ;;
-            '-v'|'--version'|'-version')
+            -v|--version|-version)
                 echo "vimpager $version"
                 quit 0
                 ;;
-            '+G'|'+')
+            +G|+)
                 vim_options="$vim_options +";
                 shift
                 ;;
-            '-N'|'--LINE-NUMBERS')
+            -N|--LINE-NUMBERS)
                 line_numbers=1
                 shift
                 ;;
-            '-c')
+            -c)
                 shift
                 extra_c="${extra_c:+$extra_c | }$1"
                 shift
                 ;;
-            '--cmd')
+            --cmd)
                 shift
                 extra_cmd="${extra_cmd:+$extra_cmd | }$1"
                 shift
                 ;;
-            '-u')
+            -u)
                 shift
                 vimrc="$1"
                 shift
                 ;;
-            '-s') # Ubuntu man passes this option to /usr/bin/pager
+            -s) # Ubuntu man passes this option to /usr/bin/pager
                 shift
                 squeeze_blank_lines=1
                 ;;
-            '--')
+            --)
                 shift
                 break
                 ;;
-            '-x')
+            -x)
                 trace=1
                 shift
                 set -x
@@ -130,11 +130,11 @@ main() {
         mkdir_options=""
     else
         # ... and /tmp otherwise
-        tmp="/tmp"
+        tmp=/tmp
     fi
 
     # Create a safe directory in which we place all other tempfiles.
-    tmp="$tmp/vimpager_${$}"
+    tmp="$tmp/vimpager_$$"
     if ! mkdir $mkdir_options "$tmp"; then
         echo "ERROR: Could not create temporary directory $tmp" >&2
         quit 1
@@ -176,7 +176,7 @@ main() {
 
     # read settings
     i=1
-    OLDIFS="$IFS"
+    OLDIFS=$IFS
     IFS='
 '
     for var in $(vim -NEnR -u "$vimrc" -i NONE --cmd 'let g:vimpager = { "enabled": 1 }' +'
@@ -234,7 +234,7 @@ main() {
                 ;;
         esac
     done
-    IFS="$OLDIFS"
+    IFS=$OLDIFS
 
     if [ -n "$msys" -o -n "$cygwin" ]; then
         # msys/cygwin may be using a native vim, and if we're not in a real
@@ -251,49 +251,49 @@ main() {
         # determine if this is an ssh session and/or $DISPLAY is set
         if [ -n "$osx" ]; then
             if [ -z "$SSH_CONNECTION" ] && command -v mvim >/dev/null; then
-                vim_cmd="mvim"
+                vim_cmd=mvim
                 gui=1
             else
-                vim_cmd="vim"
+                vim_cmd=vim
             fi
         elif [ -n "$cygwin" ]; then
             if command -v gvim >/dev/null; then
                 if [ -n "$SSH_CONNECTION" ]; then
-                    vim_cmd="vim"
+                    vim_cmd=vim
                 # The Cygwin gvim uses X
                 elif win32_native gvim; then
                     if [ -z "$DISPLAY" ]; then
-                        vim_cmd="vim"
+                        vim_cmd=vim
                     else
-                        vim_cmd='gvim'
+                        vim_cmd=gvim
                         gui=1
                     fi
                 else
-                    vim_cmd='gvim'
+                    vim_cmd=gvim
                     gui=1
                 fi
             else
-                vim_cmd="vim"
+                vim_cmd=vim
             fi
         elif [ -n "$msys" ]; then
             if [ -z "$SSH_CONNECTION" ] && command -v gvim >/dev/null; then
-                vim_cmd='gvim'
+                vim_cmd=gvim
                 gui=1
             else
-                vim_cmd="vim"
+                vim_cmd=vim
             fi
         elif [ -z "$DISPLAY" ]; then
-            vim_cmd='vim'
+            vim_cmd=vim
         else
             if command -v gvim >/dev/null; then
-                vim_cmd='gvim'
+                vim_cmd=gvim
                 gui=1
             else
-                vim_cmd="vim"
+                vim_cmd=vim
             fi
         fi
     else
-        vim_cmd='vim'
+        vim_cmd=vim
     fi
 
     rm -f gvim.exe.stackdump # for cygwin gvim, which can be part of vim
@@ -302,7 +302,7 @@ main() {
         vim_cmd="$vim_cmd -X"
     fi
 
-    ptree="$(do_ptree)"
+    ptree=$(do_ptree)
 
     # Check if called from man, perldoc or pydoc
     if echo "$ptree" | grep -Eq '([ \t]+|/)(man|[Pp]y(thon|doc)[0-9.]*|[Rr](uby|i)[0-9.]*)([ \t]|$)'; then
@@ -322,10 +322,10 @@ main() {
         set -- -
     # turn off man/perldoc support for > 1 arg
     elif [ $# -gt 1 ]; then
-        is_man=''
-        is_perldoc=''
-        is_doc=''
-        force_strip_ansi=''
+        is_man=
+        is_perldoc=
+        is_doc=
+        force_strip_ansi=
     fi
 
     file_idx=1
@@ -342,7 +342,6 @@ main() {
             filename="$(resolve_path "$file")"
         fi
 
-
         set_key orig_file_names $file_idx "$filename"
 
         # $file still holds the orginal file name.  $filename will be
@@ -350,7 +349,7 @@ main() {
         # $tmp if the file is to be opend from there instead of the
         # original location.  If $tempfile is empty the file is to be
         # opened as $file.
-        filename="$(encode_filename "$filename")"
+        filename=$(encode_filename "$filename")
         tempfile=
 
         case "$(echo "$file" | tr 'A-Z' 'a-z')" in
@@ -466,7 +465,7 @@ find_vimpagerrc_files() {
 
     # determine location of rc file
     i=1
-    OLDIFS="$IFS"
+    OLDIFS=$IFS
     IFS='
 '
     for var in $(vim -NEnR -i NONE ${vimrc:+-u "$vimrc"} +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
@@ -474,11 +473,11 @@ find_vimpagerrc_files() {
             VAL:*)
                 case $i in
                     1)
-                        vim_dir="${var#VAL:}"
+                        vim_dir=${var#VAL:}
                         ;;
                     2)
-                        user_vimrc="${var#VAL:}"
-                        user_vimrc_dir="${user_vimrc%/*}"
+                        user_vimrc=${var#VAL:}
+                        user_vimrc_dir=${user_vimrc%/*}
                         break
                         ;;
                 esac
@@ -489,18 +488,18 @@ find_vimpagerrc_files() {
     IFS="$OLDIFS"
 
     # find system vimrc
-    system_vimrc="$(vim --version | sed -n '/system vimrc file: "/{
+    system_vimrc=$(vim --version | sed -n '/system vimrc file: "/{
         s|\$VIM|'"$vim_dir"'|
         s/.*: "\([^"]*\).*/\1/p
         q
-    }')"
+    }')
 
     # find the users vimpagerrc
     if [ -n "$vimrc" ]; then
         # The vimrc file was given on the command line.
         :
     elif [ -n "$VIMPAGER_RC" ]; then
-        vimrc="$VIMPAGER_RC"
+        vimrc=$VIMPAGER_RC
     # check for vimpagerrc in same dir as vimrc in case it is set in VIMINIT
     elif [ -r "$user_vimrc_dir/.vimpagerrc" ]; then
         vimrc="$user_vimrc_dir/.vimpagerrc"
@@ -660,7 +659,7 @@ grep() {
 }
 
 awk_grep_E_q() {
-    _pat="$(printf '%s' "$1" | sed -e 's!/!\\/!g')"
+    _pat=$(printf '%s' "$1" | sed -e 's!/!\\/!g')
     shift
     awk '
         BEGIN { exit_val = 1 }
@@ -725,7 +724,7 @@ page_files() {
     if [ -n "$cat_files" ]; then
         i=1
         for cur_file in "$@"; do
-            orig_file="$(get_key orig_file_names $i)"
+            orig_file=$(get_key orig_file_names $i)
 
             if [ $# -gt 1 ]; then
                 if [ $i -gt 1 ]; then
@@ -810,7 +809,7 @@ do_ptree() {
 }
 
 win32_native() {
-    if [ "x$(get_key _win32_native "$1")" = "x1" ]; then
+    if [ "x$(get_key _win32_native "$1")" = x1 ]; then
         return 0
     else
         if [ -n "$msys" -o -n "$cygwin" ]; then

--- a/vimpager
+++ b/vimpager
@@ -124,74 +124,7 @@ main() {
 
     expand_config_vars
 
-    # determine location of rc file
-    i=1
-    OLDIFS="$IFS"
-    IFS='
-'
-    for var in $(vim -NEnR -i NONE +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
-        case "$var" in
-            VAL:*)
-                case $i in
-                    1)
-                        vim_dir="${var#VAL:}"
-                        ;;
-                    2)
-                        user_vimrc="${var#VAL:}"
-                        break
-                        ;;
-                esac
-                i=$((i + 1))
-                ;;
-        esac
-    done
-    IFS="$OLDIFS"
-
-    # find system vimrc
-    system_vimrc="$(vim --version | sed -n '/system vimrc file: "/{
-        s|\$VIM|'"$vim_dir"'|
-        s/.*: "\([^"]*\).*/\1/p
-        q
-    }')"
-
-    user_vimrc_dir="${user_vimrc%/*}"
-
-    # first check for a user ~/.vimpagerrc
-    if [ -n "$VIMPAGER_RC" ]; then
-        vimrc="$VIMPAGER_RC"
-    # check for vimpagerrc in same dir as vimrc in case it is set in VIMINIT
-    elif [ -r "$user_vimrc_dir/.vimpagerrc" ]; then
-        vimrc="$user_vimrc_dir/.vimpagerrc"
-    elif [ -r "$user_vimrc_dir/_vimpagerrc" ]; then
-        vimrc="$user_vimrc_dir/_vimpagerrc"
-    elif [ -r "$user_vimrc_dir/vimpagerrc" ]; then
-        vimrc="$user_vimrc_dir/vimpagerrc"
-    # check standard paths, according to :h initialization
-    elif [ -r ~/.vimpagerrc ]; then
-        vimrc=~/.vimpagerrc
-    elif [ -r ~/.vim/vimpagerrc ]; then
-        vimrc=~/.vim/vimpagerrc
-    elif [ -r ~/_vimpagerrc ]; then
-        vimrc=~/_vimpagerrc
-    elif [ -r ~/vimfiles/vimpagerrc ]; then
-        vimrc=~/vimfiles/vimpagerrc
-    elif [ -r "$vim_dir/_vimpagerrc" ]; then
-        vimrc="$vim_dir/_vimpagerrc"
-    fi
-
-    # use user's ~/.vimrc
-    [ -z "$vimrc" ] && vimrc="$user_vimrc"
-
-    # if no user vimrc, then check for a global /etc/vimpagerrc and fall back to NORC
-    if [ -z "$vimrc" ]; then
-        if [ -f /usr/local/etc/vimpagerrc ]; then
-            vimrc=/usr/local/etc/vimpagerrc
-        elif [ -f /etc/vimpagerrc ]; then
-            vimrc=/etc/vimpagerrc
-        else
-            vimrc=NORC
-        fi
-    fi
+    find_vimpagerrc_files
 
     # read settings
     i=1
@@ -538,6 +471,79 @@ main() {
     page_files "$@"
 
     quit $?
+}
+
+find_vimpagerrc_files() {
+    # This function will find the system and the user vimpagerrc file and set the variables $system_vimrc and $vimrc.
+
+    # determine location of rc file
+    i=1
+    OLDIFS="$IFS"
+    IFS='
+'
+    for var in $(vim -NEnR -i NONE +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
+        case "$var" in
+            VAL:*)
+                case $i in
+                    1)
+                        vim_dir="${var#VAL:}"
+                        ;;
+                    2)
+                        user_vimrc="${var#VAL:}"
+                        break
+                        ;;
+                esac
+                i=$((i + 1))
+                ;;
+        esac
+    done
+    IFS="$OLDIFS"
+
+    # find system vimrc
+    system_vimrc="$(vim --version | sed -n '/system vimrc file: "/{
+        s|\$VIM|'"$vim_dir"'|
+        s/.*: "\([^"]*\).*/\1/p
+        q
+    }')"
+
+    user_vimrc_dir="${user_vimrc%/*}"
+
+    # first check for a user ~/.vimpagerrc
+    if [ -n "$VIMPAGER_RC" ]; then
+        vimrc="$VIMPAGER_RC"
+    # check for vimpagerrc in same dir as vimrc in case it is set in VIMINIT
+    elif [ -r "$user_vimrc_dir/.vimpagerrc" ]; then
+        vimrc="$user_vimrc_dir/.vimpagerrc"
+    elif [ -r "$user_vimrc_dir/_vimpagerrc" ]; then
+        vimrc="$user_vimrc_dir/_vimpagerrc"
+    elif [ -r "$user_vimrc_dir/vimpagerrc" ]; then
+        vimrc="$user_vimrc_dir/vimpagerrc"
+    # check standard paths, according to :h initialization
+    elif [ -r ~/.vimpagerrc ]; then
+        vimrc=~/.vimpagerrc
+    elif [ -r ~/.vim/vimpagerrc ]; then
+        vimrc=~/.vim/vimpagerrc
+    elif [ -r ~/_vimpagerrc ]; then
+        vimrc=~/_vimpagerrc
+    elif [ -r ~/vimfiles/vimpagerrc ]; then
+        vimrc=~/vimfiles/vimpagerrc
+    elif [ -r "$vim_dir/_vimpagerrc" ]; then
+        vimrc="$vim_dir/_vimpagerrc"
+    fi
+
+    # use user's ~/.vimrc
+    [ -z "$vimrc" ] && vimrc="$user_vimrc"
+
+    # if no user vimrc, then check for a global /etc/vimpagerrc and fall back to NORC
+    if [ -z "$vimrc" ]; then
+        if [ -f /usr/local/etc/vimpagerrc ]; then
+            vimrc=/usr/local/etc/vimpagerrc
+        elif [ -f /etc/vimpagerrc ]; then
+            vimrc=/etc/vimpagerrc
+        else
+            vimrc=NORC
+        fi
+    fi
 }
 
 expand_config_vars() {

--- a/vimpager
+++ b/vimpager
@@ -477,7 +477,7 @@ find_vimpagerrc_files() {
     OLDIFS="$IFS"
     IFS='
 '
-    for var in $(vim -NEnR -i NONE +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
+    for var in $(vim -NEnR -i NONE ${vimrc:+-u "$vimrc"} +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
         case "$var" in
             VAL:*)
                 case $i in
@@ -486,6 +486,7 @@ find_vimpagerrc_files() {
                         ;;
                     2)
                         user_vimrc="${var#VAL:}"
+                        user_vimrc_dir="${user_vimrc%/*}"
                         break
                         ;;
                 esac
@@ -502,10 +503,11 @@ find_vimpagerrc_files() {
         q
     }')"
 
-    user_vimrc_dir="${user_vimrc%/*}"
-
-    # first check for a user ~/.vimpagerrc
-    if [ -n "$VIMPAGER_RC" ]; then
+    # find the users vimpagerrc
+    if [ -n "$vimrc" ]; then
+        # The vimrc file was given on the command line.
+        :
+    elif [ -n "$VIMPAGER_RC" ]; then
         vimrc="$VIMPAGER_RC"
     # check for vimpagerrc in same dir as vimrc in case it is set in VIMINIT
     elif [ -r "$user_vimrc_dir/.vimpagerrc" ]; then
@@ -525,20 +527,16 @@ find_vimpagerrc_files() {
         vimrc=~/vimfiles/vimpagerrc
     elif [ -r "$vim_dir/_vimpagerrc" ]; then
         vimrc="$vim_dir/_vimpagerrc"
-    fi
-
-    # use user's ~/.vimrc
-    [ -z "$vimrc" ] && vimrc="$user_vimrc"
-
-    # if no user vimrc, then check for a global /etc/vimpagerrc and fall back to NORC
-    if [ -z "$vimrc" ]; then
-        if [ -f /usr/local/etc/vimpagerrc ]; then
-            vimrc=/usr/local/etc/vimpagerrc
-        elif [ -f /etc/vimpagerrc ]; then
-            vimrc=/etc/vimpagerrc
-        else
-            vimrc=NORC
-        fi
+    # try the user's ~/.vimrc
+    elif [ -n "$user_vimrc" ]; then
+        vimrc="$user_vimrc"
+    # if no user vimrc, then check for a global /etc/vimpagerrc
+    elif [ -f /usr/local/etc/vimpagerrc ]; then
+        vimrc=/usr/local/etc/vimpagerrc
+    elif [ -f /etc/vimpagerrc ]; then
+        vimrc=/etc/vimpagerrc
+    else # fall back to NORC
+        vimrc=NORC
     fi
 }
 

--- a/vimpager
+++ b/vimpager
@@ -78,20 +78,12 @@ main() {
                 ;;
             '-c')
                 shift
-                if [ -z "$extra_c" ]; then
-                    extra_c="$1"
-                else
-                    extra_c="$extra_c | $1"
-                fi
+                extra_c="${extra_c:+$extra_c | }$1"
                 shift
                 ;;
             '--cmd')
                 shift
-                if [ -z "$extra_cmd" ]; then
-                    extra_cmd="$1"
-                else
-                    extra_cmd="$extra_cmd | $1"
-                fi
+                extra_cmd="${extra_cmd:+$extra_cmd | }$1"
                 shift
                 ;;
             '-u')


### PR DESCRIPTION
The code to find `$vimrc` and `$system_vimrc` is moved to a function.  This should make it make it easier to grasp which code belongs together and depends on what.  Also it is a step in the direction of the modularisation into functions related to #182 and https://github.com/rkitover/vimpager/issues/180#issuecomment-218985791

A vimpagerrc file given with `-u` is also used to find `$VIM`.