### PR TITLE
allow a relative symlink to vimpager to work again

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -6,13 +6,14 @@
 : if 0
     link="$0"
 
-    while true; do
+    while [ -h "$link" ]; do
         ls0="`ls -l \"$link\"`"
         new_link="`expr \"$ls0\" : '.* -> \(.*\)$'`"
-
-        [ -z "$new_link" ] && break
-
-        link="$new_link"
+        if expr "$new_link" : '/.*' > /dev/null; then
+            link="$new_link"
+        else
+            link="$(dirname $link)/$new_link"
+        fi
     done
 
     project_dir="`dirname \"$link\"`"

--- a/vimcat
+++ b/vimcat
@@ -4,19 +4,19 @@
 #! Based on _v by Magnus Woldrich: https://github.com/trapd00r/utils/blob/master/_v
 
 : if 0
-    link="$0"
+    link=$0
 
     while [ -h "$link" ]; do
-        ls0="`ls -l \"$link\"`"
-        new_link="`expr \"$ls0\" : '.* -> \(.*\)$'`"
+        ls0=`ls -l "$link"`
+        new_link=`expr "$ls0" : '.* -> \(.*\)$'`
         if expr "$new_link" : '/.*' > /dev/null; then
             link="$new_link"
         else
-            link="$(dirname $link)/$new_link"
+            link=`dirname "$link"`/"$new_link"
         fi
     done
 
-    project_dir="`dirname \"$link\"`"
+    project_dir=`dirname "$link"`
 
     . "$project_dir""/inc/prologue.sh"
 

--- a/vimpager
+++ b/vimpager
@@ -12,16 +12,17 @@ fi
 # FIND REAL PARENT DIRECTORY
 link=$0
 
-while true; do
-    ls0=`ls -l "$link"`
-    new_link=`expr "$ls0" : '.* -> \(.*\)$'`
-
-    [ -z "$new_link" ] && break
-
-    link=$new_link
+while [ -h "$link" ]; do
+    ls0="`ls -l \"$link\"`"
+    new_link="`expr \"$ls0\" : '.* -> \(.*\)$'`"
+    if expr "$new_link" : '/.*' > /dev/null; then
+        link="$new_link"
+    else
+        link="$(dirname $link)/$new_link"
+    fi
 done
 
-project_dir=`dirname "$link"`
+project_dir="`dirname \"$link\"`"
 # END OF FIND REAL PARENT DIRECTORY
 
 . "$project_dir/inc/prologue.sh"

--- a/vimpager
+++ b/vimpager
@@ -13,16 +13,16 @@ fi
 link=$0
 
 while [ -h "$link" ]; do
-    ls0="`ls -l \"$link\"`"
-    new_link="`expr \"$ls0\" : '.* -> \(.*\)$'`"
+    ls0=`ls -l "$link"`
+    new_link=`expr "$ls0" : '.* -> \(.*\)$'`
     if expr "$new_link" : '/.*' > /dev/null; then
         link="$new_link"
     else
-        link="$(dirname $link)/$new_link"
+        link=`dirname "$link"`/"$new_link"
     fi
 done
 
-project_dir="`dirname \"$link\"`"
+project_dir=`dirname "$link"`
 # END OF FIND REAL PARENT DIRECTORY
 
 . "$project_dir/inc/prologue.sh"


### PR DESCRIPTION
When using a relative symlink (e.g. `ln -s ../.vim/bundle/vimpager/vimpager vp`)
to invoke `vimpager` or `vimcat`, the path to `prologue.sh` was being
calculated relative to the symlink file itself rather than to the actual
location of script. Also, we only need to perform this resolution on
symlinks (i.e. `while [ -h "$link" ]; do`).

(this worked prior to 1126ee)