### PR TITLE
fix broken ${vimrc:+-u "$vimrc"} due to bad IFS interaction

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -348,7 +348,7 @@ find_vimpagerrc_files() {
     OLDIFS=$IFS
     IFS='
 '
-    for var in $("$tvim" -NEnR -i NONE ${vimrc:+-u "$vimrc"} +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
+    for var in $(IFS=$OLDIFS; "$tvim" -NEnR -i NONE ${vimrc:+-u "$vimrc"} +'call writefile(["", "VAL:" . $VIM, "VAL:" . $MYVIMRC], "/dev/stderr")' +q </dev/tty 2>&1 >/dev/null); do
         case "$var" in
             VAL:*)
                 case $i in
@@ -418,7 +418,7 @@ read_vim_settings() {
     OLDIFS=$IFS
     IFS='
 '
-    for var in $("$tvim" -NEnR ${vimrc:+-u "$vimrc"} -i NONE --cmd 'let g:vimpager = { "enabled": 1 }' +'
+    for var in $(IFS=$OLDIFS; "$tvim" -NEnR ${vimrc:+-u "$vimrc"} -i NONE --cmd 'let g:vimpager = { "enabled": 1 }' +'
         if !exists("g:vimpager.gvim")
             if !exists("g:vimpager_use_gvim")
                 let g:vimpager.gvim = 0


### PR DESCRIPTION
For some reason, those "add -u if variable is set" things do not
have the intended effect due to the IFS change. It looks like
vim gets '-u $vimrc' as a single argument.

Here is a test example:

    #!/usr/bin/sh

    vimrc=~/.vimpagerrc

    IFS='
    '

    vim ${vimrc:+-u "$vimrc"}

Fixed by temporarily restoring the IFS on the subshell