### PR TITLE
Fix manpage build with pandoc 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ man/%.1: markdown_src/%.md
 	@if command -v pandoc >/dev/null; then \
 	    echo 'generating $@'; \
 	    ${MKPATH} `dirname '$@'` 2>/dev/null || true; \
-	    ${PANDOC} -Ss -f markdown_github $< -o $@; \
+	    ${PANDOC} -s -f markdown_github $< -o $@; \
 	else \
 	    if [ ! -r docs-warn-stamp ]; then \
 		echo >&2; \
@@ -283,7 +283,7 @@ html/%.html: %.md.work
 	@if command -v pandoc >/dev/null; then \
 	    echo 'generating $@'; \
 	    ${MKPATH} `dirname '$@'` 2>/dev/null || true; \
-	    ${PANDOC} -Ss --toc -f markdown_github $< -o $@; \
+	    ${PANDOC} -s --toc -f markdown_github $< -o $@; \
 	    rm -f $<; \
 	else \
 	    if [ ! -r docs-warn-stamp ]; then \

--- a/scripts/pandoc-sh
+++ b/scripts/pandoc-sh
@@ -33,13 +33,20 @@ fi
 
 first_arg=1
 for arg in "$@"; do
-    [ $first_arg -eq 1 ] && set -- && first_arg=0
+    if [ $first_arg -eq 1 ]; then
+        if [ $old_pandoc -eq 1 ]; then
+            set -- "-S"
+        else
+            set --
+        fi
+        first_arg=0
+    fi
 
     if [ "$arg" = markdown_github ]; then
 	if [ $old_pandoc -eq 1 ]; then
 	    set -- "$@" markdown
 	else
-	    set -- "$@" markdown_github+pandoc_title_block
+	    set -- "$@" markdown_github+pandoc_title_block+smart
 	fi
     else
 	set -- "$@" "$arg"

--- a/scripts/pandoc-sh
+++ b/scripts/pandoc-sh
@@ -27,7 +27,11 @@ title="`echo \"$title\" | \
 # use markdown instead of markdown_github on older versions
 # and markdown_github+pandoc_title_block on newer ones
 old_pandoc=0
-if ! ( pandoc --help | grep markdown_github >/dev/null ); then
+pandoc_version=$(pandoc --version | head -1 | cut -d' ' -f2)
+pandoc_major_version=${pandoc_version%%.*}
+pandoc_minor_version=${pandoc_version#*.}
+pandoc_minor_version=${pandoc_minor_version%%.*}
+if [ $pandoc_major_version -le 1 ] && [ $pandoc_minor_version -le 9 ]; then
     old_pandoc=1
 fi
 


### PR DESCRIPTION
Pandoc 2.0 removed `-S` from its command line arguments.

Also, the check for the availability of `markdown_github` was broken as `pandoc --help` no longer prints the list of input formats.

Fixes #227