### PR TITLE
vimcat: kill potential leftover cat process

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -47,6 +47,10 @@ quit() {
 
         kill "$tail_pid" >/dev/null 2>&1
         do_sleep 100
+        if [ -f ${tmp_dir}/cat_pid ]; then
+            cat_pid=$(cat ${tmp_dir}/cat_pid)
+            kill "$cat_pid" >/dev/null 2>&1
+        fi
         kill -9 "$tail_pid" >/dev/null 2>&1
 
         cd "${tmp_dir%/*}" 2>/dev/null # some systems cannot remove CWD
@@ -302,7 +306,9 @@ do
 
         (
             while :; do
-                cat "$out_fifo"
+                cat "$out_fifo" & cat_pid=$!
+                echo ${cat_pid} > ${tmp_dir}/cat_pid
+                wait ${cat_pid}
             done
         ) &
         tail_pid=$!

--- a/vimcat
+++ b/vimcat
@@ -47,8 +47,8 @@ quit() {
 
         kill "$tail_pid" >/dev/null 2>&1
         do_sleep 100
-        if [ -f ${tmp_dir}/cat_pid ]; then
-            cat_pid=$(cat ${tmp_dir}/cat_pid)
+        if [ -f "${tmp_dir}/cat_pid" ]; then
+            cat_pid=$(cat "${tmp_dir}/cat_pid")
             kill "$cat_pid" >/dev/null 2>&1
         fi
         kill -9 "$tail_pid" >/dev/null 2>&1
@@ -307,7 +307,7 @@ do
         (
             while :; do
                 cat "$out_fifo" & cat_pid=$!
-                echo ${cat_pid} > ${tmp_dir}/cat_pid
+                echo ${cat_pid} > "${tmp_dir}/cat_pid"
                 wait ${cat_pid}
             done
         ) &


### PR DESCRIPTION
Fix for leftover cat process, as described in issue #231.

It's not the cleanest solution, and I haven't confirmed that the issue occurs for anyone else yet, but I thought I'd open the PR in case it's confirmed and you want a quick fix.