### PR TITLE
Don't force filetype when python is a parent process

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -589,7 +589,7 @@ parse_pstree() {
     ptree=$(do_ptree)
 
     # Check if called from man, perldoc or pydoc
-    if echo "$ptree" | grep -Eq '([ \t]+|/)(man|[Pp]y(thon|doc)[0-9.]*|[Rr](uby|i)[0-9.]*)([ \t]|$)'; then
+    if echo "$ptree" | grep -Eq '([ \t]+|/)(man|[Pp]ydoc[0-9.]*|[Rr](uby|i)[0-9.]*)([ \t]|$)'; then
         is_man=1
         is_doc=1
         force_strip_ansi=1


### PR DESCRIPTION
Matching "python" as the parent process is too generic to force
filetype: sometimes it happens that a python program launches a shell
and from that shell vimpager would have a broken filetype detection.

See the following example:

```
------------- launch-shell.py ------------------------
import subprocess

subprocess.check_call(['/bin/bash'])
--------------------------------------------------------
```

In the new subshell everything would look like a man page, e.g.:

$ python launch-shell.py
$ vimpager launch-shell.py

In particular I experienced this with gst-build
(https://gitlab.freedesktop.org/gstreamer/gst-build/) which launches
a subshell with a modified environment.

So don't match against python when forcing the file type.

The same may apply to Ruby, vimpager is trying too hard sometimes. :)