### PR TITLE
make vimcat honor VIMPAGER_VIM before other vims

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -24,7 +24,9 @@ project_dir=`dirname "$link"`
 version="$(cd "$project_dir" && git describe 2>/dev/null) (git)" || version="$version_tag (checkout)"
 runtime=$project_dir
 
-if command -v vim.basic >/dev/null; then
+if [ -n "$VIMPAGER_VIM" ]; then
+    vim=$VIMPAGER_VIM
+elif command -v vim.basic >/dev/null; then
     vim=vim.basic
 elif command -v vim >/dev/null; then
     vim=vim


### PR DESCRIPTION
Issue #246 was caused by "vim" being a weird shell function that did some extra steps before firing off vim. However, I had VIMPAGER_VIM exported to point to neovim and I've just now noticed that vimcat doesn't take this into account. With this patch, #246 is solved.