### PR TITLE
Use $TMPDIR if set

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -194,7 +194,7 @@ for arg in "$@"; do
     esac
 done
 
-tmp_dir=/tmp
+tmp_dir=${TMPDIR:-/tmp}
 mkdir_options="-m 700"
 
 case "$(uname -s)" in

--- a/vimpager
+++ b/vimpager
@@ -320,7 +320,7 @@ find_tmp_directory() {
         mkdir_options=
     else
         # ... and /tmp otherwise
-        tmp=/tmp
+        tmp=${TMPDIR:-/tmp}
     fi
 
     # Create a safe directory in which we place all other tempfiles.


### PR DESCRIPTION
It's good to honor `$TMPDIR` as it's a UNIX standard. On some systems (e.g. Termux) /tmp is not available