### PR TITLE
Fix get_key/set_key to properly handle files with dollar signs in name

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -806,11 +806,13 @@ encode_filename() {
 
 # emulate arrays
 set_key() {
-    eval "$1_$2=\"$3\""
+    key="$1_$2"
+    eval "$key="'$3'
 }
 
 get_key() {
-    eval "echo \"\${$1_$2}\""
+    key="$1_$2"
+    eval "echo \$${key}"
 }
 
 # this actually runs vim or gvim, or vimcat, or just cats the file


### PR DESCRIPTION
Previously, files having the `$` character in their filenames would fail to open, due to the part after the `$` being erroneously interpreted as a shell variable in set_key/get_key. This small change fixes that.