### PR TITLE
Change git:// protocol to https://

### DIFF
--- a/markdown_src/vimpager.md
+++ b/markdown_src/vimpager.md
@@ -32,7 +32,7 @@ For vimcat see [here](markdown/vimcat.md) or 'man vimcat'.
 On Ubuntu or Debian, use the following to install a package:
 
 ```bash
-git clone git://github.com/rkitover/vimpager
+git clone https://github.com/rkitover/vimpager
 cd vimpager
 sudo make install-deb
 ```
@@ -42,7 +42,7 @@ To just build the '.deb' use `make build-deb` instead.
 Otherwise use 'make install':
 
 ```bash
-git clone git://github.com/rkitover/vimpager
+git clone https://github.com/rkitover/vimpager
 cd vimpager
 sudo make install
 ```


### PR DESCRIPTION
`git://` hangs everywhere I tried it (home PC, AWS EC2), not quite sure why, probably a GitHub thing, they've been heavily pushing using https:// lately to get their repos.

Sorry I don't know how to build these files so only edited source.