### PR TITLE
Do not copy the whole file into a bash expression

### DIFF
--- a/vimpager
+++ b/vimpager
@@ -283,7 +283,7 @@ main() {
         if [ ! -s "${tempfile:-$file}" \
             -a $# -eq 1 \
             -o "$(head -c 1 "${tempfile:-$file}")" = "" \
-            -a "$(wc -l < "${tempfile:-$file}")" -eq 1 ]; then
+            -a "$(head -2 "${tempfile:-$file}" | wc -l)" -eq 1 ]; then
 
             quit 0
         fi

--- a/vimpager
+++ b/vimpager
@@ -282,7 +282,7 @@ main() {
         # if file is zero length, or one blank line (cygwin), and is only arg, exit
         if [ ! -s "${tempfile:-$file}" \
             -a $# -eq 1 \
-            -o "$(cat "${tempfile:-$file}")" = "" \
+            -o "$(head -c 1 "${tempfile:-$file}")" = "" \
             -a "$(wc -l < "${tempfile:-$file}")" -eq 1 ]; then
 
             quit 0


### PR DESCRIPTION
Avoid `cat`ing the whole file into a bash subexpression.